### PR TITLE
31 admin can edit an artisan

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -61,7 +61,7 @@ class AdminsController < ApplicationController
   def require_super_admin
     return if session[:role] == 'super_admin'
 
-    redirect_to root_path, alert: 'You are not authorized to perform this action.'
+    redirect_to root_path, alert: 'You do not have the necessary permissions to perform this action.'
   end
 
   def authorize_admin_edit!
@@ -94,7 +94,7 @@ class AdminsController < ApplicationController
 
   def handle_unauthorized_role_change
     Rails.logger.warn "Unauthorized role change attempt by Admin ##{current_user.id}"
-    redirect_to edit_admin_path(@admin), alert: 'You are not authorized to change your role.'
+    redirect_to edit_admin_path(@admin), alert: 'You do not have the necessary permissions to change this role.'
   end
 
   def handle_update_failure

--- a/app/controllers/artisans_controller.rb
+++ b/app/controllers/artisans_controller.rb
@@ -116,12 +116,15 @@ class ArtisansController < ApplicationController
   end
 
   # Utility Methods
-
   def handle_status_change
-    flash[:notice] = if artisan_params[:active].present?
-                       "Artisan has been successfully #{artisan_params[:active] == 'true' ? 'reactivated' : 'deactivated'}."
-                     else
-                       'Artisan details have been successfully updated.'
-                     end
+    messages = []
+
+    if artisan_params[:active].present?
+      messages << "Artisan has been successfully #{artisan_params[:active] == 'true' ? 'reactivated' : 'deactivated'}."
+    end
+
+    messages << 'Artisan details have been successfully updated.' if artisan_params.except(:active).to_h.any? { |_key, value| value.present? }
+
+    flash[:notice] = messages.join(' ')
   end
 end

--- a/spec/features/admins/admin/admin_creates_admin_spec.rb
+++ b/spec/features/admins/admin/admin_creates_admin_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Admin Creates Admin', type: :feature do
     it 'cannot access the admin creation page' do
       visit new_admin_path
 
-      expect(page).to have_content('You are not authorized to perform this action.')
+      expect(page).to have_content('You do not have the necessary permissions to perform this action.')
       expect(current_path).to eq(root_path)
     end
   end

--- a/spec/features/admins/admin/admin_edits_admin_spec.rb
+++ b/spec/features/admins/admin/admin_edits_admin_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Admin Edits Their Own Account', type: :feature do
 
       page.driver.submit :patch, admin_path(admin), { admin: { role: 'super_admin' } }
 
-      expect(page).to have_content('You are not authorized to change your role.')
+      expect(page).to have_content('You do not have the necessary permissions to change this role.')
       expect(admin.reload.role).to eq('regular') # Role remains unchanged
     end
 

--- a/spec/features/admins/artisan/admin_edits_artisan_spec.rb
+++ b/spec/features/admins/artisan/admin_edits_artisan_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'AdminEditsArtisan', type: :feature do
+  let(:super_admin) { FactoryBot.create(:admin, email: 'superadmin@example.com', password: 'password', role: 'super_admin') }
+  let(:admin) { FactoryBot.create(:admin, email: 'admin@example.com', password: 'password') }
+  let(:unauthorized_admin) { FactoryBot.create(:admin, email: 'unauthorizedadmin@example.com', password: 'password') }
+  let!(:artisan) { FactoryBot.create(:artisan, admin: admin, store_name: 'Artisan Wonders', email: 'artisan@example.com') }
+
+  scenario 'Super admin edits an artisan and verifies changes', :js do
+    login_as(super_admin)
+    expect_to_be_on_dashboard_for(super_admin)
+
+    navigate_to_artisan_edit_page(admin: admin, artisan: artisan)
+    update_artisan_details(store_name: 'Updated Artisan Wonders', email: 'updated_artisan@example.com', status: 'Inactive')
+    verify_success_message_deactivated
+    verify_updated_details(artisan: artisan, store_name: 'Updated Artisan Wonders', email: 'updated_artisan@example.com', status: false)
+  end
+
+  scenario 'Admin edits their own artisan and verifies changes', :js do
+    login_as(admin)
+    expect_to_be_on_dashboard_for(admin)
+
+    navigate_to_artisan_edit_page(admin: admin, artisan: artisan)
+    update_artisan_details(store_name: 'Updated Artisan Wonders', email: 'updated_artisan@example.com', status: 'Active')
+    verify_success_message_reactivated
+    verify_updated_details(artisan: artisan, store_name: 'Updated Artisan Wonders', email: 'updated_artisan@example.com', status: true)
+  end
+
+  scenario 'Unauthorized admin attempts to edit artisan and is redirected', :js do
+    login_as(unauthorized_admin)
+    expect_to_be_on_dashboard_for(unauthorized_admin)
+
+    navigate_to_artisan_show_page(admin: admin, artisan: artisan)
+    expect(page).not_to have_link('Edit Artisan Data')
+
+    attempt_unauthorized_edit(admin: admin, artisan: artisan)
+  end
+
+  # Helper Methods
+
+  def navigate_to_artisan_show_page(admin:, artisan:)
+    visit admin_artisans_path(admin)
+    click_link 'Show Artisan Wonders'
+    expect(page).to have_current_path(artisan_path(id: artisan.id))
+  end
+
+  def navigate_to_artisan_edit_page(admin:, artisan:)
+    navigate_to_artisan_show_page(admin: admin, artisan: artisan)
+    click_link 'Edit Artisan Data'
+    expect(page).to have_current_path(edit_admin_artisan_path(admin_id: admin.id, id: artisan.id))
+  end
+
+  def update_artisan_details(store_name:, email:, status:)
+    fill_in 'Store Name', with: store_name
+    fill_in 'Email', with: email
+    select status, from: 'Account Status'
+    click_button 'Update Artisan'
+  end
+
+  def verify_success_message_deactivated
+    expect(page).to have_content('Artisan has been successfully deactivated. Artisan details have been successfully updated.')
+  end
+
+  def verify_success_message_reactivated
+    expect(page).to have_content('Artisan has been successfully reactivated. Artisan details have been successfully updated.')
+  end
+
+  def verify_updated_details(artisan:, store_name:, email:, status:)
+    visit artisan_path(artisan)
+    expect(page).to have_content(store_name)
+    expect(artisan.reload.email).to eq(email)
+    expect(artisan.reload.active).to eq(status)
+  end
+
+  def attempt_unauthorized_edit(admin:, artisan:)
+    visit edit_admin_artisan_path(admin_id: admin.id, id: artisan.id)
+    expect(page).to have_current_path(artisan_path(artisan))
+    expect(page).to have_content('You do not have the necessary permissions to edit this artisan.')
+  end
+end


### PR DESCRIPTION
## **Pull Request Summary: Admin Edits Artisan**

### **Overview**
This pull request introduces feature specs and refactors the functionality for admins (super_admin and owning admin) to edit artisan details, ensuring clear authorization checks and improved user feedback.

### **Key Updates**
1. **Authorization Messages**:
   - Updated error and success messages for clarity and consistency when unauthorized actions are attempted.

2. **Feature Specs**:
   - Added comprehensive feature tests to cover:
     - Super admin editing artisan details and status.
     - Admin editing their own artisan details.
     - Unauthorized admin attempting to edit an artisan and being redirected appropriately.

3. **Refactored Flash Messages**:
   - Consolidated the handling of status change flash messages for deactivating/reactivating artisans and updating their details into a single, concise implementation.

### **Testing**
- All feature specs are passing, including:
  - Super admin editing artisan details and verifying changes.
  - Admin editing their own artisan details.
  - Unauthorized admin attempting to edit and being redirected.
- RuboCop checks were addressed by refactoring scenarios into smaller steps using helper methods.

