### PR TITLE
37 admin views artisan products

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -98,3 +98,8 @@ Lint/Syntax:
 
 AllCops:
   SuggestExtensions: false
+
+# To allow for the use of 1, 2 etc in variable names in specs
+RSpec/IndexedLet:
+  Exclude:
+    - "spec/**/*"

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -6,12 +6,34 @@
 
 <div id="products">
   <% @products.each do |product| %>
-    <%= render product %>
-      <p>
-        <%= link_to "Show #{product.name}", artisan_product_path(@artisan, product), class: 'btn btn-secondary' %>
+    <div class="product">
+      <h2>
+        <%= product.name %>
+      </h2>
+      <p><strong>Description:</strong>
+        <%= product.description %>
       </p>
-      <% end %>
+      <p><strong>Price:</strong> $<%= product.price %>
+      </p>
+
+      <% if current_user==@artisan %>
+        <p><strong>Stock:</strong>
+          <%= product.stock %>
+        </p>
+        <% end %>
+
+          <p>
+            <%= link_to "Show #{product.name}", artisan_product_path(@artisan, product), class: 'btn btn-secondary' %>
+          </p>
+    </div>
+    <% end %>
 </div>
 
-<%= link_to 'Add New Product' , new_artisan_product_path(@artisan), class: 'btn btn-primary' %>
-<%= link_to 'Back to Dashboard', dashboard_artisan_path(@artisan), class: 'btn btn-primary' %>
+<% if current_user.is_a?(Admin) %>
+  <%= link_to 'Back to All Artisans', admin_artisans_path(current_user), class: 'btn btn-secondary' %>
+    <% end %>
+
+      <% if current_user==@artisan %>
+        <%= link_to 'Add New Product', new_artisan_product_path(@artisan), class: 'btn btn-primary' %>
+          <%= link_to 'Back to Dashboard', dashboard_artisan_path(@artisan), class: 'btn btn-primary' %>
+            <% end %>

--- a/spec/features/admins/artisan/admin_views_artisan_products_spec.rb
+++ b/spec/features/admins/artisan/admin_views_artisan_products_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin views artisan products', type: :feature do
+  let!(:admin1) { create(:admin) }
+  let!(:admin2) { create(:admin) }
+
+  let!(:artisan1) { create_list(:artisan, 3, admin: admin1) }
+  let!(:artisan2) { create_list(:artisan, 3, admin: admin2) }
+
+  let!(:products1) do
+    artisan1.each do |artisan|
+      create_list(:product, 2, artisan: artisan, stock: 100)
+    end
+  end
+
+  let!(:products2) do
+    artisan2.each do |artisan|
+      create_list(:product, 2, artisan: artisan, stock: 100)
+    end
+  end
+
+  before { login_as(admin1) }
+
+  describe "Admin views their own artisans' products" do
+    it 'displays all products belonging to an artisan' do
+      artisan = artisan1.first
+      visit artisan_products_path(artisan.id)
+
+      artisan.products.each do |product|
+        expect(page).to have_content(product.name)
+        expect(page).to have_content(product.description)
+        expect(page).to have_content(product.price)
+        expect(page).not_to have_content(product.stock)
+      end
+    end
+
+    it 'does not allow admin to edit or delete products' do
+      artisan = artisan1.first
+      visit artisan_products_path(artisan.id)
+
+      artisan.products.each do |product|
+        expect(page).not_to have_link('Edit')
+        expect(page).not_to have_link('Delete')
+      end
+    end
+
+    it "navigates to a product's show page" do
+      artisan = artisan1.first
+      product = artisan.products.first
+      visit artisan_products_path(artisan.id)
+
+      click_link product.name
+      expect(current_path).to eq(artisan_product_path(artisan, product))
+    end
+  end
+
+  describe "Admin views other admins' artisans' products" do
+    it 'displays products belonging to artisans managed by another admin' do
+      artisan = artisan2.first
+      visit artisan_products_path(artisan.id)
+
+      artisan.products.each do |product|
+        expect(page).to have_content(product.name)
+        expect(page).to have_content(product.description)
+        expect(page).to have_content(product.price)
+        expect(page).not_to have_content(product.stock)
+      end
+    end
+
+    it "does not allow admin to edit or delete products of other admins' artisans" do
+      artisan = artisan2.first
+      visit artisan_products_path(artisan.id)
+
+      artisan.products.each do |product|
+        expect(page).not_to have_link('Edit')
+        expect(page).not_to have_link('Delete')
+      end
+    end
+  end
+
+  describe 'Navigation links' do
+    it "has a link to navigate back to admin's artisan index page" do
+      artisan = artisan1.first
+      visit artisan_products_path(artisan.id)
+
+      click_link 'Back to All Artisans'
+      expect(current_path).to eq(admin_artisans_path(admin1))
+    end
+  end
+
+  scenario 'Admin sees a message if no artisans are found', :js do
+    # Create a new admin with no artisans
+    empty_admin = FactoryBot.create(:admin, email: 'empty_admin@example.com', password: 'password')
+    login_as(empty_admin)
+    visit admin_artisans_path(empty_admin)
+
+    # Verify message is displayed
+    expect(page).to have_content('No artisans found. Create your first artisan!')
+  end
+
+  scenario "Admin does not see artisan-specific links on the artisan's products page" do
+    # Log in as an admin
+    login_as(admin1)
+
+    # Visit the artisan's products page
+    visit artisan_products_path(artisan1)
+
+    # Verify that the admin does not see artisan-specific links
+    expect(page).not_to have_link('Add New Product', href: new_artisan_product_path(artisan1))
+    expect(page).not_to have_link('Back to Dashboard', href: dashboard_artisan_path(artisan1))
+  end
+end

--- a/spec/features/admins/artisan/admin_views_artisan_products_spec.rb
+++ b/spec/features/admins/artisan/admin_views_artisan_products_spec.rb
@@ -7,26 +7,24 @@ RSpec.describe 'Admin views artisan products', type: :feature do
   let!(:artisan1) { create_list(:artisan, 3, admin: admin1) }
   let!(:artisan2) { create_list(:artisan, 3, admin: admin2) }
 
-  let!(:products1) do
+  before do
     artisan1.each do |artisan|
       create_list(:product, 2, artisan: artisan, stock: 100)
     end
-  end
 
-  let!(:products2) do
     artisan2.each do |artisan|
       create_list(:product, 2, artisan: artisan, stock: 100)
     end
-  end
 
-  before { login_as(admin1) }
+    login_as(admin1)
+  end
 
   describe "Admin views their own artisans' products" do
     it 'displays all products belonging to an artisan' do
       artisan = artisan1.first
       visit artisan_products_path(artisan.id)
 
-      artisan.products.each do |product|
+      artisan.reload.products.each do |product|
         expect(page).to have_content(product.name)
         expect(page).to have_content(product.description)
         expect(page).to have_content(product.price)
@@ -38,7 +36,7 @@ RSpec.describe 'Admin views artisan products', type: :feature do
       artisan = artisan1.first
       visit artisan_products_path(artisan.id)
 
-      artisan.products.each do |product|
+      artisan.reload.products.each do |_product|
         expect(page).not_to have_link('Edit')
         expect(page).not_to have_link('Delete')
       end
@@ -46,7 +44,7 @@ RSpec.describe 'Admin views artisan products', type: :feature do
 
     it "navigates to a product's show page" do
       artisan = artisan1.first
-      product = artisan.products.first
+      product = artisan.reload.products.first
       visit artisan_products_path(artisan.id)
 
       click_link product.name
@@ -59,7 +57,7 @@ RSpec.describe 'Admin views artisan products', type: :feature do
       artisan = artisan2.first
       visit artisan_products_path(artisan.id)
 
-      artisan.products.each do |product|
+      artisan.reload.products.each do |product|
         expect(page).to have_content(product.name)
         expect(page).to have_content(product.description)
         expect(page).to have_content(product.price)
@@ -71,7 +69,7 @@ RSpec.describe 'Admin views artisan products', type: :feature do
       artisan = artisan2.first
       visit artisan_products_path(artisan.id)
 
-      artisan.products.each do |product|
+      artisan.reload.products.each do |_product|
         expect(page).not_to have_link('Edit')
         expect(page).not_to have_link('Delete')
       end
@@ -103,10 +101,10 @@ RSpec.describe 'Admin views artisan products', type: :feature do
     login_as(admin1)
 
     # Visit the artisan's products page
-    visit artisan_products_path(artisan1)
+    visit artisan_products_path(artisan1.first)
 
     # Verify that the admin does not see artisan-specific links
-    expect(page).not_to have_link('Add New Product', href: new_artisan_product_path(artisan1))
-    expect(page).not_to have_link('Back to Dashboard', href: dashboard_artisan_path(artisan1))
+    expect(page).not_to have_link('Add New Product', href: new_artisan_product_path(artisan1.first))
+    expect(page).not_to have_link('Back to Dashboard', href: dashboard_artisan_path(artisan1.first))
   end
 end


### PR DESCRIPTION
This pull request introduces the functionality for admins to view an artisan's products in a **read-only** capacity. 
---

## Features Implemented
1. **Admin Views Artisan Products**:
   - Admins can see all products belonging to a specific artisan.
   - Displayed details include:
     - Product name
     - Description
     - Price
   - Stock information is **hidden** for admins, as it's not relevant to their role.

2. **Role-Based Visibility**:
   - Links for adding a new product and returning to the artisan's dashboard are **only visible to the owning artisan**.
   - Admin-specific navigation links:
     - "Back to All Artisans" is displayed only to admins for returning to the `admin_artisans#index` page.

3. **Navigation**:
   - Admins can click on a product to navigate to its individual show page.
   - "Back to All Artisans" link navigates correctly to the admin's artisan index page.

4. **Read-Only Access**:
   - Admins cannot edit or delete products belonging to any artisan.

---

## Tests Added
- **Admin Views Their Own Artisan's Products**:
  - Ensures all products are displayed with correct details (name, description, price) but no stock information.
  - Confirms no "Edit" or "Delete" links are visible.
  - Navigates to a product's show page.

- **Admin Views Other Admins' Artisans' Products**:
  - Verifies that admins can view products managed by other admins.
  - Ensures the same read-only access (no "Edit" or "Delete" links).

- **Navigation Links**:
  - Ensures "Back to All Artisans" link is visible and functional for admins.

- **Role-Based Visibility**:
  - Confirms artisan-specific links ("Add New Product" and "Back to Dashboard") are not visible to admins.

- **No Artisans Found Message**:
  - Displays an appropriate message for admins with no assigned artisans.

---

## Refactor
- Replaced instance variables (`@artisan1`, `@artisan2`) with `let` to align with RSpec best practices.
- Added `artisan.reload` in tests to ensure associated products are properly loaded.

---

## RuboCop Compliance
- Addressed RuboCop offenses related to instance variables by refactoring to use `let`.
- Removed `RSpec/InstanceVariable` offense entirely while maintaining test clarity and performance.

