### PR TITLE
53 add product visibility toggle

### DIFF
--- a/app/models/artisan.rb
+++ b/app/models/artisan.rb
@@ -2,9 +2,20 @@ class Artisan < ApplicationRecord
   belongs_to :admin
 
   has_many :products, dependent: :destroy
+
   has_secure_password
 
   validates :store_name, presence: true
   validates :email, presence: true, uniqueness: true,
                     format: { with: URI::MailTo::EMAIL_REGEXP, message: 'must be a valid email address' }
+
+  after_update :update_product_visibility, if: -> { saved_change_to_active? }
+
+  private
+
+  def update_product_visibility
+    products.find_each do |product|
+      product.update(visible: active)
+    end
+  end
 end

--- a/db/migrate/20250106023326_add_visible_to_products.rb
+++ b/db/migrate/20250106023326_add_visible_to_products.rb
@@ -1,0 +1,5 @@
+class AddVisibleToProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :products, :visible, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_02_194130) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_06_023326) do
   create_table "admins", force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_02_194130) do
     t.integer "artisan_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "visible", default: true, null: false
     t.index ["artisan_id"], name: "index_products_on_artisan_id"
   end
 

--- a/spec/models/artisan_spec.rb
+++ b/spec/models/artisan_spec.rb
@@ -22,4 +22,38 @@ RSpec.describe Artisan, type: :model do
   describe 'secure password' do
     it { is_expected.to have_secure_password }
   end
+
+  describe 'callbacks' do
+    let(:artisan) { create(:artisan, admin: admin, active: true) }
+    let!(:products) { create_list(:product, 2, artisan: artisan, stock: 100) }
+
+    it 'ensures new products are created with visible: true by default' do
+      product = create(:product, artisan: artisan)
+      expect(product.visible).to eq(true)
+    end
+
+    context 'when the artisan is deactivated' do
+      it 'sets all associated products to visible: false' do
+        artisan.update(active: false)
+
+        artisan.products.each do |product|
+          expect(product.reload.visible).to be(false)
+        end
+      end
+    end
+
+    context 'when the artisan is reactivated' do
+      before do
+        artisan.update(active: false) # Deactivate first to test reactivation
+      end
+
+      it 'sets all associated products to visible: true' do
+        artisan.update(active: true)
+
+        artisan.products.each do |product|
+          expect(product.reload.visible).to be(true)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/artisan_spec.rb
+++ b/spec/models/artisan_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Artisan, type: :model do
 
   describe 'callbacks' do
     let(:artisan) { create(:artisan, admin: admin, active: true) }
-    let!(:products) { create_list(:product, 2, artisan: artisan, stock: 100) }
 
     it 'ensures new products are created with visible: true by default' do
       product = create(:product, artisan: artisan)
@@ -33,6 +32,10 @@ RSpec.describe Artisan, type: :model do
     end
 
     context 'when the artisan is deactivated' do
+      before do
+        create_list(:product, 2, artisan: artisan, stock: 100) # Create products for the specific context
+      end
+
       it 'sets all associated products to visible: false' do
         artisan.update(active: false)
 
@@ -44,6 +47,7 @@ RSpec.describe Artisan, type: :model do
 
     context 'when the artisan is reactivated' do
       before do
+        create_list(:product, 2, artisan: artisan, stock: 100) # Create products for the specific context
         artisan.update(active: false) # Deactivate first to test reactivation
       end
 

--- a/spec/models/artisan_spec.rb
+++ b/spec/models/artisan_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Artisan, type: :model do
 
     it 'ensures new products are created with visible: true by default' do
       product = create(:product, artisan: artisan)
-      expect(product.visible).to eq(true)
+      expect(product.visible).to be(true)
     end
 
     context 'when the artisan is deactivated' do


### PR DESCRIPTION
This pull request implements functionality to automatically toggle the visibility of an artisan's products based on their activation status. 

---

### **Changes Made**
1. **Artisan Model Callback**:
   - Added an `after_update` callback to toggle the `visible` attribute of associated products based on the artisan's `active` status.
   - Ensured changes are applied only when the `active` status changes using the `saved_change_to_active?` method.

2. **Database Default**:
   - Products now default to `visible: true` upon creation.

3. **RSpec Tests**:
   - Added tests to verify:
     - The default `visible` value is `true` for new products.
     - All associated products are updated to `visible: false` when the artisan is deactivated.
     - All associated products are updated to `visible: true` when the artisan is reactivated.
